### PR TITLE
Refactor LoanFormModal to handle form submission and reset fields; up…

### DIFF
--- a/src/modules/loans/components/LoanFormModal.tsx
+++ b/src/modules/loans/components/LoanFormModal.tsx
@@ -91,6 +91,11 @@ const LoanFormModal: React.FC<LoanFormModalProps> = ({
     onClose();
   };
 
+  const handleSubmit = async (values: any) => {
+    onSubmit(values);
+    form.resetFields();
+    onClose();
+  };
 
   return (
     <Modal
@@ -121,7 +126,7 @@ const LoanFormModal: React.FC<LoanFormModalProps> = ({
       centered
       destroyOnClose
     >
-      <Form id="loan-form" form={form} layout="vertical" onFinish={onSubmit}>
+      <Form id="loan-form" form={form} layout="vertical" onFinish={handleSubmit}>
         <Row gutter={16}>
           <Col span={6}>
             <Form.Item

--- a/src/modules/loans/pages/LoansPage.tsx
+++ b/src/modules/loans/pages/LoansPage.tsx
@@ -648,9 +648,9 @@ const LoansPage = () => {
       }
       setModalOpen(false);
       setLoan(emptyLoan);
+    } finally {
       await loadTools();
       await loadLoans();
-    } finally {
       setLoading(false);
       setIsCreating(false);
       setIsEditing(false);


### PR DESCRIPTION
This pull request introduces improvements to the loan form submission handling and fixes the order of operations in the loans page cleanup logic. The most important changes include adding a dedicated `handleSubmit` function in the `LoanFormModal` component and ensuring proper cleanup in the `LoansPage` component.

### Loan form submission improvements:

* [`src/modules/loans/components/LoanFormModal.tsx`](diffhunk://#diff-66a2f39d710e3a3ac57997e9514c0498c5857233d8399a47c3d9d195c8db48a4R94-R98): Added a new `handleSubmit` function to reset form fields and close the modal after submission. Updated the `Form` component to use `handleSubmit` instead of directly calling `onSubmit`. [[1]](diffhunk://#diff-66a2f39d710e3a3ac57997e9514c0498c5857233d8399a47c3d9d195c8db48a4R94-R98) [[2]](diffhunk://#diff-66a2f39d710e3a3ac57997e9514c0498c5857233d8399a47c3d9d195c8db48a4L124-R129)

### Loans page cleanup fix:

* [`src/modules/loans/pages/LoansPage.tsx`](diffhunk://#diff-1be2fe262ea35b1de755197e425eb53a32a985c9bbbf3763ef087f3aaeb42dc8R651-L653): Fixed the `finally` block to ensure `loadTools` and `loadLoans` are called before resetting loading and editing states.…date LoansPage to ensure loading states are managed correctly